### PR TITLE
[FIX] Avoid cert errors

### DIFF
--- a/travis/travis_install
+++ b/travis/travis_install
@@ -3,7 +3,11 @@
 # Copyright 2016 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+# Fix Cert errors
+pip install requests[security]
+
 # Always install package and requirements
+
 if [ -f test_requirements.txt ]; 
 then
   pip install -r ./test_requirements.txt


### PR DESCRIPTION
* Install `certifi` python package to circumvent requests SSL errors