### PR TITLE
[FIX] Remove PyPi repository

### DIFF
--- a/travis/travis_after_success_pypi
+++ b/travis/travis_after_success_pypi
@@ -6,7 +6,6 @@
 pip install twine
 
 echo "[pypi]
-repository: https://pypi.python.org/pypi
 username: ${PYPI_USER:=laslabs}
 password: ${PYPI_PASSWORD}" > $HOME/.pypirc
 


### PR DESCRIPTION
* Remove PyPi repository to allow twin to properly work (https://stackoverflow.com/questions/45207128/failed-to-upload-packages-to-pypi-410-gone)